### PR TITLE
more useful message when symbol conversion size is unknown

### DIFF
--- a/slyr_community/converters/symbols.py
+++ b/slyr_community/converters/symbols.py
@@ -3183,7 +3183,12 @@ class SymbolConverter:  # pylint: disable=too-many-public-methods
                 elif marker_type == QgsSimpleMarkerSymbolLayerBase.AsteriskFill:
                     simple_size = (1.3632460 * layer.size) / 2.0
 
-            simple_size *= conversion_properties.get('shape_size_factor', 1)
+            try:
+                simple_size *= conversion_properties.get('shape_size_factor', 1)
+            except NameError as e:
+                if "simple_size" in str(e):
+                    raise RuntimeError(f"Unknown size multipyer for {marker_type}.") from e
+                raise e
 
             stroke_only_symbol = not QgsSimpleMarkerSymbolLayerBase.shapeIsFilled(
                 marker_type) or conversion_properties.get('outline_only',


### PR DESCRIPTION
Previously, the program would just have raised a NameError. Now it raises a RuntimeError which contains the marker type which is important information.