### PR TITLE
1. s1.3 License: reworded and added in order to point and give power to the entitlements in sch 1 for specifications

### DIFF
--- a/docs/src/license/version1_4.md
+++ b/docs/src/license/version1_4.md
@@ -1,6 +1,6 @@
 # SLYR End User License Agreement
 
-## Version 1.3
+## Version 1.4
 
 This Licensing Agreement ('Agreement') is made by and between:
 
@@ -178,7 +178,7 @@ and includes any modifications, enhancements, or developments made to, or arisin
 
 **“Moral Rights”** has the meaning given in the *Copyright Act 1968 (Cth)*.
 
-**"Remote User"** means a staff member of the Licensee who is formally assigned to a particular physical workplace location of the Licensee, but who accesses and uses the Software from a location other than that workplace, including while travelling or working offsite.
+**"Remote User"** means a staff member of the Licensee who is formally assigned to a particular physical workplace location of the Licensee, but who accesses and uses the Software from a location other than that workplace, including while traveling or working offsite.
 
 **“Specifications”** means the Software technical specifications requirements set out in Schedule 1, all of which may be
 updated by North Road by written notice.

--- a/docs/src/license/version1_4.md
+++ b/docs/src/license/version1_4.md
@@ -1,0 +1,215 @@
+# SLYR End User License Agreement
+
+## Version 1.3
+
+This Licensing Agreement ('Agreement') is made by and between:
+
+**North Road Consulting Pty Limited ABN 80 769 844 078 of 21 Kiel Mountain Rd, Woombye QLD 4559** ('North Road') and license holders of the SLYR QGIS Plugin Tool ('the licensee').
+
+*The parties have agreed that North Road will license the Software to the Licensee and will provide upgrades and updates (if any) to the Software in consideration for the License Fee. In consideration of the mutual covenants, terms, and conditions set out in this Agreement, the parties agree as follows:*
+
+### 1. License
+
+1.1. Subject to the Licensee’s continued compliance with all the terms of this Agreement (including, without limitation, payment of all fees payable under this Agreement), North Road grants the Licensee a non-exclusive, non-transferable license (and accordingly does not allow sublicensing of the Software to any other party) to:
+
+(a) use the Software within the scope of the License Type; and
+
+(b) install or imbed copies of the Software in accordance with the License Type.
+
+1.2. North Road reserves the right to amend or vary the terms of this Agreement. If North Road varies or amends this Agreement in accordance with this provision, North Road will provide the Licensee with a written copy of the variation or amendment to this Agreement via the SLYR software. Any variation or amendment of this Agreement in accordance with this provision will take immediate effect and where the Licensee continues to use the Software, it confirms its agreement with the amended terms.
+
+1.3. The scope of use, including the entitlements attaching to each License, is further described in Schedule 1 (Specifications), which forms part of this Agreement.
+
+### 2. Restrictions
+
+2.1. The Software is owned by North Road and is copyrighted and licensed, not sold. The Licensee receives no title to or ownership of any copy of the Software itself and any Intellectual Property Rights contained in the Software continues to be at all times owned by North Road. The Licensee receives no rights to the Software other than those specifically
+granted in clause 1.
+
+2.2. Unless it is in accordance with this Agreement, or North Road provides its written consent, the Licensee must not, and must not permit any of its officers, employees, agents, contractors, or related companies to:
+
+(a) modify, create derivative works from, distribute, publicly display, publicly perform, or sublicense the Software or
+its associated content; or
+
+(b) use the Software or its content for the purpose of service bureau, time-sharing, web-hosting, software as a service,
+cloud or other service or technology or in any way allow third parties to exploit the Software;
+
+(c) reverse engineer, disassemble or decompile or otherwise attempt to derive any of the Software’s source code; or
+
+(d) remove, alter or obscure any proprietary notices, labels or marks in the Software or North Road’s terms of use or privacy policy contained in the Software.
+
+2.3. The parties acknowledge and agree that, notwithstanding anything to the contrary in this Agreement, no license is granted (whether expressly, by implication or otherwise) under this Agreement for use of the Software beyond the applicable Term or outside the scope of the applicable License Type.
+
+2.4. The Licensee warrants that it will reproduce all copyright notices and other legends of ownership on each copy, or partial copy, of the Software.
+
+2.5. The Licensed Software is provided solely for the Licensee’s internal use. The Licensee may use the Software only for projects and activities conducted directly by or on behalf of the Licensee. The Licensee must not use the Software to provide services to third parties, including but not limited to consulting, analysis, development, or data processing services. The Software may not be used as part of any commercial offering, hosted service, or deliverable provided to clients or other external parties without the prior written consent of the Licensor.
+
+2.6. If the Licensee intends to use the Software as part of a service offering to a third party or client, a separate license must be purchased for each such client. This ensures that the client is appropriately licensed and that use of the Software aligns with the Licensor’s terms of distribution and support.
+
+### 3. Updates and Upgrades
+
+3.1. Subject to clause 1 and subject to the Licensee ensuring its equipment, hardware and software complies with the Specifications, North Road may (if required) provide upgrades and updates to the Software to the Licensee.
+
+3.2. For the purpose of providing the Licensee with upgrades and updates to the Software, the Licensee must ensure that all the software, data or other information has been backed-up and no data loss as a result of an update will be held as North Road’s responsibility.
+
+3.3. The Licensee agrees and acknowledges North Road is not liable for:
+
+(a) any damage caused to the Licensee’s equipment (inclusive of, without limitation, any hardware or software of the
+Licensee); or
+(b) any costs, damage or delay arising from the upgrades and updates to the Software.
+
+3.4. If, during the provision of upgrades and updates, North Road determines that additional services are required that are:
+
+(a) not part of the upgrades and update;
+
+(b) services that arose out of the Licensee’s modifications to the Software; or
+
+(c) arose out of the Licensee breaching one of the restrictions set out in clause 2 of this Agreement; (“Additional Services”), the Licensee will be liable to pay North Road for such Additional Services, based on the normal charge out rates for the North Road representatives undertaking those Additional Services.
+
+### 4. Payment
+
+4.1. The Licensee must pay North Road the License Fee in accordance with Schedule 2 (License Fee), prior to delivery of the Software, unless otherwise agreed in writing by North Road.  
+
+4.2. The License Fee is payable in the currency specified on the invoice and is exclusive of all applicable taxes (including, without limitation, VAT, GST or similar sales taxes), which are the responsibility of the Licensee and must be paid in addition to the License Fee.  
+
+4.3. Payment must be made by the due date specified on the invoice. North Road reserves the right to withhold delivery of the Software until full payment has been received.  
+
+### 5. Warranties
+
+5.1. North Road warrants that, during the Term of this Agreement, the Software will perform materially as described in the Specifications.
+
+5.2. North Road warrants that it is the owner of the Software and each and every component of the Software, or, it is the recipient of a valid license of the Software, and it has and will maintain the full power and authority to grant the license and Intellectual Property Rights granted in this Agreement without the further consent of any third party.
+
+5.3. Each party warrants that it has the full right and authority to enter into, execute, and perform its obligations under this Agreement and that no pending or threatened claim or litigation known to it would have a material adverse impact on its ability to perform as required by this Agreement.
+
+5.4. Except for the express warranties specified in this clause 5 and the statutory warranties contained in the *Competition and Consumer Act 2010* (Cth), North Road makes no warranties, either express or implied, including without limitation any implied warranties of merchantability or fitness for a particular purpose. North Road does not warrant that the Software will operate uninterrupted or error-free, or that North Road will correct all Software defects. The Licensee is responsible for the results obtained from the use of the Software. The Licensee agrees and acknowledge North Road provides no warranty regarding, and will have no responsibility for, any claim arising out of:
+
+(a) a modification of the Software made by anyone other than North Road, unless North Road approves such modification in
+writing; or
+
+(b) use of the Software in combination with any operating system not authorized in the Specifications or with hardware or software specifically forbidden by the Specifications.
+
+5.5. Notwithstanding anything in this Agreement, if the *Competition and Consumer Act 2010* (Cth) provides that there is a guarantee in relation to any good or service supplied by North Road in connection with this Agreement and North Road’s liability for failing to comply with that guarantee cannot be excluded, but may be limited, then:
+
+1. The limitation in clause 7 and any other limitation on North Road’s liability under this Agreement do not apply to that liability.  
+2. Instead North Road’s liability for such failure is limited, at North Road’s option, as follows:
+
+(a) **Products** - the lesser of:
+
+    i. the replacement of the products or the of supply of equivalent products; or
+
+    ii. the repair of the products; or
+
+    iii. the payment of the cost of replacing the products or acquiring equivalent products; or
+
+    iv. the payment of the cost of having the products repaired; or
+
+(b) in the case of services:
+
+    i. the supply of the services again; or 
+    
+    ii.the payment of the cost of having the services supplied again.
+
+### 6 Indemnities
+
+6.1. The Licensee will indemnify, defend, and hold North Road harmless against any loss, injury, death, cost, damage, claim, suit or proceeding caused by, arising out of or in connection with the Licensee breaching the terms of this Agreement.
+
+### 7 Limitation of Liability
+
+7.1. The aggregate liability of North Road, its employees, sub- consultants and related bodies corporate to the Licensee arising out of or in connection with or relating in any manner to the performance or non-performance of obligations in connection with this Agreement or the use of the Software, whether based in contract, tort (including negligence), equity, statute, or on any other basis in law or equity, is limited to the license fee payable by the Licensee at the time of the claim (“Liability Limitation”).
+
+7.2. The Liability Limitation does not apply to:
+
+(a) liability arising from North Road’s fraudulent or wilful misconduct; or
+
+(b) liability which by law North Road cannot contract out of.
+
+7.3. Notwithstanding any contrary provision in this Agreement, in no circumstances shall either North Road or the Licensee be liable for:
+
+(a) pure economic losses that extend beyond the reasonable contemplation of the parties at the time of entering into the contract (there is no liability for indirect or special losses); or
+
+(b) any pure economic loss that relates to or comprises a claim for loss of profits of any kind, loss or corruption of data, interruption of business, loss of customer or clients and customer and/or client losses, increase in operational expense or overhead expense, loss of revenue of any kind or additional costs of funds or any other form of damages ( liquidated or others) under any other agreement.
+
+### 8 Notices
+
+8.1. A notice or other communication ("notice") connected with this Agreement has no legal effect unless it is in writing and is:
+
+(a) delivered by hand at the address of the representative of the party; or
+
+(b) sent by e-mail to the e-mail address of the representative of the party and is acknowledged by the representative of the party either by e-mail or post.
+
+8.2. A notice is deemed given and received:
+
+(a) if delivered by hand, upon delivery; or
+
+(b) if the representative of the party sends an acknowledgement that the e-mail was received.
+
+(c) A party may change its address or by giving notice of that change to each other party.
+
+### 9 General
+
+9.1. This Agreement is to be governed by the law in force in Queensland, Australia. Each party submits to the exclusive jurisdiction of the courts of Queensland, Australia.
+
+9.2. A right created by this Agreement cannot be waived except in writing signed by the party entitled to that right. Delay by a party in exercising a right does not constitute a waiver of that right, nor will a waiver (either wholly or in part) by a party of a right operate as a subsequent waiver of the same or of any other right of that party.
+
+9.3. If any provision of the Agreement is held to be unenforceable, invalid, void or illegal for any reason, then that provision will to the extent possible be deemed to have been severed and omitted from the Agreement without affecting the enforceability, validity or legality of the remaining provisions (or parts of those provisions) which will continue
+in full force and effect.
+
+9.4. The parties are independent contractors and will so represent themselves in all regards. Neither party is the agent of the other and neither may bind the other in any way.
+
+### 10 Definitions
+
+In this Agreement the following terms have the following defined meanings:
+
+**“Agreement”** means this contract between North Road and the Licensee which is formed once the Software is delivered to the Licensee or payment of the invoice is remitted by the Licensee to North Road (whichever occurs first).
+
+**“Commencement Date”** means date of supply of the Software for the Initial Term
+
+**“Intellectual Property Rights”** means any intellectual or industrial property rights, whether registered or unregistered, including:  
+
+(a) all patents, trade-marks, copyright, designs, trade secrets, know-how and other rights in any design, materials, processes, documents and methods of working; and
+
+(b) all licenses and other rights to use or to grant the use of those items referred in paragraph (a);
+
+and includes any modifications, enhancements, or developments made to, or arising out of, the same, but excludes Moral Rights.
+
+**“License Fee”** means the fee set out in Schedule 2 which is payable by the Licensee to North Road to purchase a license to use the Software.
+
+**“Licensee”** means the party to whom the Software is delivered and identified in the invoice submitted by North Road.
+
+**“Moral Rights”** has the meaning given in the *Copyright Act 1968 (Cth)*.
+
+**"Remote User"** means a staff member of the Licensee who is formally assigned to a particular physical workplace location of the Licensee, but who accesses and uses the Software from a location other than that workplace, including while travelling or working offsite.
+
+**“Specifications”** means the Software technical specifications requirements set out in Schedule 1, all of which may be
+updated by North Road by written notice.
+
+**“Software”** means SLYR and any content associated with, developed from or created by the software application.
+
+**"Work From Home User”** means a staff member of the Licensee who is formally assigned to a particular physical workplace location of the Licensee, but who routinely performs their duties from their personal residence and accesses the Software from that residence.
+
+### Schedule 1 – Specifications
+
+A SLYR license grants access to the Software based on the number of licenses purchased. The entitlements are as follows:  
+
+**1. Single License Entitlement**  
+1.1 A single SLYR license entitles the Licensee to installations accessible for up to twenty (20) staff members, within one (1) single physical workplace location.  
+
+**2. Multiple License Entitlements**  
+2.1 Where the Licensee purchases multiple licenses, such licenses may be allocated to cover additional staff or additional physical workplace locations.  
+
+2.2 The allocation of multiple licenses is subject to the following rules:  
+(a) **Covering Additional Locations:** A separate license is required for each distinct physical workplace location where the Software will be used. *Example, a Licensee with offices in two different cities must hold a minimum of two (2) licenses, one for each office.*  
+(b) **Covering Additional Staff at a Single Location:** If a single workplace location has more than twenty (20) staff requiring access to the Software, additional licenses must be purchased for that location. Each additional license purchased for that location increases the permitted staff count by twenty (20).  
+(c) **Non-Transferability:** Licenses allocated to a specific workplace location are not transferable between different workplace locations.
+
+**3. Remote and Work From Home Users**  
+3.1 Remote or “work from home” users shall be counted towards the staff limit of the physical workplace location to which they are formally assigned.  
+
+3.2 Such users are entitled to utilize the license attached to their usual workplace office location, provided that location is appropriately licensed for its total number of assigned staff (inclusive of both in-office and remote users).  
+
+### Schedule 2 - License Fee
+
+2.1 A license is available for either:
+
+(a) the price previously agreed upon in writing via a quote or proforma invoice supplied by North Road or an approved reseller of the Software; or  
+(b) if no previously agreed price was supplied, the advertised price of the Software as published at time of purchase.


### PR DESCRIPTION
2. s4: Payment: reworded and added in order to point and give power to the entitlements in sch2 for license fee
3. s5.5 formatting amended
4. Definitions: added in definitions for work from home and remote user
5. Definitions: amended definitions: IP rights (formatting)
6. sch 1 has been updated
7. sch2 has been reformatted and wording has been updated
8. formatting throughout: 'a.' replaced with '(a)' i.e. dots replaced with brackets