### PR TITLE
fix: sanitize invalid Windows filename characters in file paths

### DIFF
--- a/slyr_community/bintools/file_utils.py
+++ b/slyr_community/bintools/file_utils.py
@@ -33,26 +33,18 @@ class FileUtils:
 
     @staticmethod
     def clean_symbol_name_for_file(symbol_name):
-        """nasty little function to remove some characters which will choke"""
+        """Remove characters which are invalid in Windows filenames or may cause issues"""
         file_name = symbol_name.strip()
-        file_name = file_name.replace("/", "_")
-        file_name = file_name.replace(">", "_")
-        file_name = file_name.replace("<", "_")
-        file_name = file_name.replace("\\", "_")
-        file_name = file_name.replace("?", "_")
-        file_name = file_name.replace("*", "_")
-        file_name = file_name.replace('"', "_")
-        file_name = file_name.replace("'", "_")
-        file_name = file_name.replace(":", "_")
-        file_name = file_name.replace(";", "_")
+        # Remove Windows forbidden characters: < > : " / \ | ? *
+        file_name = re.sub(r'[<>:"/\\|?*]', "_", file_name)
+        # Remove control characters and other problematic chars
+        file_name = re.sub(r'[\x00-\x1f\x7f;,\']', "_", file_name)
+        # Replace spaces with underscores
         file_name = file_name.replace(" ", "_")
-        file_name = file_name.replace(",", "_")
-        file_name = file_name.replace("|", "_")
+        # Collapse multiple underscores
         file_name = re.sub(r"_+", "_", file_name)
-        if file_name.endswith("_"):
-            file_name = file_name[:-1]
-        if file_name.startswith("_"):
-            file_name = file_name[1:]
+        # Remove leading/trailing underscores
+        file_name = file_name.strip("_")
         if not file_name:
             return "__"
         # limit to 30 chars

--- a/slyr_community/converters/layers.py
+++ b/slyr_community/converters/layers.py
@@ -40,6 +40,7 @@ from qgis.core import (
 
 from .context import Context
 from .converter import NotImplementedException
+from .utils import ConversionUtils
 
 from .raster_layer import RasterLayerConverter
 from .vector_layer import VectorLayerConverter
@@ -471,7 +472,8 @@ class LayerConverter:
             if len(layers) == 1:
                 url = output_file
             else:
-                url = os.path.join(path, "{} {}.qml".format(basename, name))
+                safe_name = ConversionUtils.safe_filename(name)
+                url = os.path.join(path, "{} {}.qml".format(basename, safe_name))
 
             status, res = vl.saveNamedStyle(url)
             if not res and on_error:


### PR DESCRIPTION
- Improve clean_symbol_name_for_file() with comprehensive regex-based sanitization
- Remove all Windows forbidden characters: < > : " / \ | ? *
- Sanitize layer names when creating QML files
- Fixes OSError when processing symbols/layers with pipe characters